### PR TITLE
Specify alooma account name

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -6,16 +6,16 @@ import time
 
 ALOOMA_USERNAME = os.environ.get('ALOOMA_USERNAME')
 ALOOMA_PASSWORD = os.environ.get('ALOOMA_PASSWORD')
+ALOOMA_ACCOUNT_NAME = os.environ.get('ALOOMA_ACCOUNT_NAME')
 DATADOG_API_KEY = os.environ.get('DATADOG_API_KEY')
 MINUTES_SLEEP = int(os.environ.get('SLEEP_INTERVAL_MINUTES', '10'))
 SECONDS_SLEEP = MINUTES_SLEEP * 60
 
 
-api = alooma.Alooma(
-    hostname='app.alooma.com',
-    port=443,
+api = alooma.Client(
     username=ALOOMA_USERNAME,
     password=ALOOMA_PASSWORD,
+    account_name=ALOOMA_ACCOUNT_NAME
 )
 
 datadog.initialize(api_key=DATADOG_API_KEY)


### PR DESCRIPTION
The user has multiple accounts, just pick one for now. Eventually we might want to do multiple and tag the datadog events with the account name.