### PR TITLE
Rescue exception and print error

### DIFF
--- a/restream_job.py
+++ b/restream_job.py
@@ -1,4 +1,9 @@
 from api_config import api
 
-print "Restreaming alooma queue"
-api.start_restream()
+if __name__ == '__main__':
+    print "Restreaming alooma queue."
+    try:
+      api.start_restream()
+      print "Successfully restreamed alooma queue."
+    except Exception as e:
+      print e


### PR DESCRIPTION
We got a page for the Alooma queue. I don't see the hourly restream_job in the Heroku logs for the one that [supposedly ran](https://cl.ly/29bbbe8c8ef4) about ~2 hours ago. The next hour, it definitely ran successfully - I saw it in the [logs](https://cl.ly/1e4e692cd5d4) and in the Alooma dashboard. 

If there was an error on the previous run, I expected to see a log that said "[Timestamp] heroku[scheduler.1420]: Process exited with status 1". But maybe the job is somehow occasionally failing silently?  This PR is to print the error.