### PR TITLE
Increase timeout from 1 to 15 minutes

### DIFF
--- a/api_config.py
+++ b/api_config.py
@@ -4,10 +4,11 @@ import alooma
 ALOOMA_USERNAME = os.environ.get('ALOOMA_USERNAME')
 ALOOMA_PASSWORD = os.environ.get('ALOOMA_PASSWORD')
 ALOOMA_ACCOUNT_NAME = os.environ.get('ALOOMA_ACCOUNT_NAME')
+REQUEST_TIMEOUT = os.environ.get('REQUEST_TIMEOUT', 300)
 
 api = alooma.Client(
     username=ALOOMA_USERNAME,
     password=ALOOMA_PASSWORD,
     account_name=ALOOMA_ACCOUNT_NAME,
-    timeout=900
+    timeout=REQUEST_TIMEOUT
 )

--- a/api_config.py
+++ b/api_config.py
@@ -8,5 +8,6 @@ ALOOMA_ACCOUNT_NAME = os.environ.get('ALOOMA_ACCOUNT_NAME')
 api = alooma.Client(
     username=ALOOMA_USERNAME,
     password=ALOOMA_PASSWORD,
-    account_name=ALOOMA_ACCOUNT_NAME
+    account_name=ALOOMA_ACCOUNT_NAME,
+    timeout=900
 )

--- a/restream_job.py
+++ b/restream_job.py
@@ -1,9 +1,23 @@
+from os import environ
+from requests import exceptions
 from api_config import api
 
+MAX_RETRIES = os.environ.get('RESTREAM_MAX_RETRIES', 10)
+
 if __name__ == '__main__':
-    print "Restreaming alooma queue."
-    try:
-      api.start_restream()
-      print "Successfully restreamed alooma queue."
-    except Exception as e:
-      print e
+  print "Restreaming alooma queue."
+  retries = 0
+
+  while True:
+      try:
+          api.start_restream()
+          print "Successfully restreamed alooma queue."
+      except requests.exceptions.Timeout as e:
+          print e
+          if retries <= MAX_RETRIES
+              "Retrying..."
+              retries += 1
+              continue
+      except Exception as e:
+          print e
+      break

--- a/restream_job.py
+++ b/restream_job.py
@@ -5,19 +5,16 @@ from api_config import api
 MAX_RETRIES = os.environ.get('RESTREAM_MAX_RETRIES', 10)
 
 if __name__ == '__main__':
-  print "Restreaming alooma queue."
-  retries = 0
-
-  while True:
-      try:
-          api.start_restream()
-          print "Successfully restreamed alooma queue."
-      except requests.exceptions.Timeout as e:
-          print e
-          if retries <= MAX_RETRIES
-              "Retrying..."
-              retries += 1
-              continue
-      except Exception as e:
-          print e
-      break
+    print "Restreaming alooma queue."
+    for _ in range(MAX_RETRIES)::
+        try:
+            api.start_restream()
+            print "Successfully restreamed alooma queue."
+        except requests.exceptions.Timeout as e:
+            print e
+            print "Retrying..."
+            continue
+        except Exception as e:
+            print e
+        else:
+            break

--- a/restream_job.py
+++ b/restream_job.py
@@ -2,7 +2,7 @@ from os import environ
 from requests import exceptions
 from api_config import api
 
-MAX_RETRIES = os.environ.get('RESTREAM_MAX_RETRIES', 10)
+MAX_RETRIES = os.environ.get('RESTREAM_MAX_RETRIES', 3)
 
 if __name__ == '__main__':
     print "Restreaming alooma queue."

--- a/restream_job.py
+++ b/restream_job.py
@@ -1,5 +1,6 @@
 from os import environ
 from requests import exceptions
+from time import sleep
 from api_config import api
 
 MAX_RETRIES = os.environ.get('RESTREAM_MAX_RETRIES', 3)
@@ -13,6 +14,7 @@ if __name__ == '__main__':
         except requests.exceptions.Timeout as e:
             print e
             print "Retrying..."
+            sleep(5)
             continue
         except Exception as e:
             print e


### PR DESCRIPTION
Sometimes the restream job was completing fine, but sometimes we'd get the following error:
`HTTPSConnectionPool(host='app.alooma.com', port=443): Read timed out. (read timeout=60)`

I think this is because the client was timing out if it didn't receive a response from the API within 60 seconds, the DEFAULT_TIMEOUT on the client.  https://github.com/Aloomaio/alooma-python/blob/e01c7dba0b1d69fd34e34116950a2cbb2014c358/alooma/alooma.py#L76

This makes sense - when I restreamed from the dashboard earlier today, it took a long time to complete (maybe even 10 minutes, though I didn't time it).
 
I didn't see this in the reference docs, but from the code, it looks like we can set our own timeout. 